### PR TITLE
feat(bitbucket): add support for Bitbucket Pipelines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3494,6 +3494,7 @@ dependencies = [
  "keyring",
  "pipedash-plugin-api",
  "pipedash-plugin-argocd",
+ "pipedash-plugin-bitbucket",
  "pipedash-plugin-buildkite",
  "pipedash-plugin-github",
  "pipedash-plugin-gitlab",
@@ -3539,6 +3540,22 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "pipedash-plugin-bitbucket"
+version = "0.0.8"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "pipedash-plugin-api",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "urlencoding",
 ]
 
 [[package]]
@@ -6053,6 +6070,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
   "crates/pipedash",
   "crates/pipedash-plugin-api",
+  "crates/pipedash-plugin-bitbucket",
   "crates/pipedash-plugin-buildkite",
   "crates/pipedash-plugin-github",
   "crates/pipedash-plugin-gitlab",
@@ -30,6 +31,7 @@ keyring = { version = "3", features = ["apple-native", "windows-native", "linux-
 octocrab = "0.47.1"
 # Internal workspace crates
 pipedash-plugin-api = { path = "crates/pipedash-plugin-api" }
+pipedash-plugin-bitbucket = { path = "crates/pipedash-plugin-bitbucket" }
 pipedash-plugin-buildkite = { path = "crates/pipedash-plugin-buildkite" }
 pipedash-plugin-github = { path = "crates/pipedash-plugin-github" }
 pipedash-plugin-gitlab = { path = "crates/pipedash-plugin-gitlab" }
@@ -54,5 +56,7 @@ tauri-plugin-os = "2"
 # Error Handling
 thiserror = "2.0"
 tokio = { version = "1", features = ["full"] }
+# URL encoding
+urlencoding = "2.1"
 # Logging
 tracing = "0.1"

--- a/crates/pipedash-plugin-bitbucket/Cargo.toml
+++ b/crates/pipedash-plugin-bitbucket/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "pipedash-plugin-bitbucket"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+[dependencies]
+async-trait.workspace = true
+base64.workspace = true
+chrono.workspace = true
+futures.workspace = true
+pipedash-plugin-api.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+urlencoding.workspace = true

--- a/crates/pipedash-plugin-bitbucket/src/client.rs
+++ b/crates/pipedash-plugin-bitbucket/src/client.rs
@@ -1,0 +1,294 @@
+use std::sync::OnceLock;
+
+use pipedash_plugin_api::{
+    PaginatedResponse,
+    PaginationParams,
+    PluginError,
+    PluginResult,
+    RetryPolicy,
+};
+use reqwest::StatusCode;
+
+use crate::types::{
+    PaginatedResponse as BitbucketPaginatedResponse,
+    Pipeline,
+    PipelineStep,
+    Repository,
+    TriggerPipelineRequest,
+    User,
+    Workspace,
+};
+
+pub struct BitbucketClient {
+    http_client: reqwest::Client,
+    api_url: String,
+    retry_policy: RetryPolicy,
+    user_cache: OnceLock<User>,
+}
+
+impl BitbucketClient {
+    pub fn new(http_client: reqwest::Client, api_url: String) -> Self {
+        Self {
+            http_client,
+            api_url: api_url.trim_end_matches('/').to_string(),
+            retry_policy: RetryPolicy::default(),
+            user_cache: OnceLock::new(),
+        }
+    }
+
+    pub async fn get_user(&self) -> PluginResult<User> {
+        if let Some(user) = self.user_cache.get() {
+            return Ok(user.clone());
+        }
+
+        let user: User =
+            self.retry_policy
+                .retry(|| async {
+                    let url = format!("{}/user", self.api_url);
+                    let response = self.http_client.get(&url).send().await.map_err(|e| {
+                        PluginError::NetworkError(format!("Failed to get user: {}", e))
+                    })?;
+
+                    self.handle_response(response).await
+                })
+                .await?;
+
+        let _ = self.user_cache.set(user.clone());
+        Ok(user)
+    }
+
+    pub async fn list_workspaces(&self) -> PluginResult<Vec<Workspace>> {
+        let mut all_workspaces = Vec::new();
+        let mut next_url = Some(format!("{}/workspaces?pagelen=100", self.api_url));
+        const MAX_PAGES: usize = 10;
+        let mut page_count = 0;
+
+        while let Some(url) = next_url.take() {
+            if page_count >= MAX_PAGES {
+                break;
+            }
+
+            let paginated: BitbucketPaginatedResponse<Workspace> = self
+                .retry_policy
+                .retry(|| async {
+                    let response = self.http_client.get(&url).send().await.map_err(|e| {
+                        PluginError::NetworkError(format!("Failed to list workspaces: {}", e))
+                    })?;
+                    self.handle_response(response).await
+                })
+                .await?;
+
+            all_workspaces.extend(paginated.values);
+            next_url = paginated.next;
+            page_count += 1;
+        }
+
+        Ok(all_workspaces)
+    }
+
+    pub async fn list_repositories(
+        &self, workspace: &str, params: &PaginationParams,
+    ) -> PluginResult<PaginatedResponse<Repository>> {
+        self.retry_policy
+            .retry(|| async {
+                let url = format!(
+                    "{}/repositories/{}?pagelen={}&page={}",
+                    self.api_url, workspace, params.page_size, params.page
+                );
+                let response = self.http_client.get(&url).send().await.map_err(|e| {
+                    PluginError::NetworkError(format!("Failed to list repositories: {}", e))
+                })?;
+
+                let paginated: BitbucketPaginatedResponse<Repository> =
+                    self.handle_response(response).await?;
+
+                let total_count = paginated.size.unwrap_or(paginated.values.len());
+                Ok(PaginatedResponse::new(
+                    paginated.values,
+                    params.page,
+                    params.page_size,
+                    total_count,
+                ))
+            })
+            .await
+    }
+
+    pub async fn list_all_repositories(
+        &self, params: &PaginationParams,
+    ) -> PluginResult<PaginatedResponse<Repository>> {
+        self.retry_policy
+            .retry(|| async {
+                let url = format!(
+                    "{}/repositories?role=member&pagelen={}&page={}",
+                    self.api_url, params.page_size, params.page
+                );
+                let response = self.http_client.get(&url).send().await.map_err(|e| {
+                    PluginError::NetworkError(format!("Failed to list repositories: {}", e))
+                })?;
+
+                let paginated: BitbucketPaginatedResponse<Repository> =
+                    self.handle_response(response).await?;
+
+                let total_count = paginated.size.unwrap_or(paginated.values.len());
+                Ok(PaginatedResponse::new(
+                    paginated.values,
+                    params.page,
+                    params.page_size,
+                    total_count,
+                ))
+            })
+            .await
+    }
+
+    /// Bitbucket API max pagelen is 100
+    pub async fn list_pipelines(
+        &self, workspace: &str, repo_slug: &str, limit: usize,
+    ) -> PluginResult<Vec<Pipeline>> {
+        let pagelen = limit.min(100);
+        self.retry_policy
+            .retry(|| async {
+                let url = format!(
+                    "{}/repositories/{}/{}/pipelines?pagelen={}&sort=-created_on",
+                    self.api_url, workspace, repo_slug, pagelen
+                );
+                let response = self.http_client.get(&url).send().await.map_err(|e| {
+                    PluginError::NetworkError(format!("Failed to list pipelines: {}", e))
+                })?;
+
+                let paginated: BitbucketPaginatedResponse<Pipeline> =
+                    self.handle_response(response).await?;
+                Ok(paginated.values)
+            })
+            .await
+    }
+
+    pub async fn list_steps(
+        &self, workspace: &str, repo_slug: &str, pipeline_uuid: &str,
+    ) -> PluginResult<Vec<PipelineStep>> {
+        // Bitbucket UUIDs have curly braces that need URL encoding
+        let uuid_with_braces = if pipeline_uuid.starts_with('{') {
+            pipeline_uuid.to_string()
+        } else {
+            format!("{{{}}}", pipeline_uuid)
+        };
+        let encoded_uuid = urlencoding::encode(&uuid_with_braces);
+
+        self.retry_policy
+            .retry(|| async {
+                let url = format!(
+                    "{}/repositories/{}/{}/pipelines/{}/steps",
+                    self.api_url, workspace, repo_slug, encoded_uuid
+                );
+                let response = self.http_client.get(&url).send().await.map_err(|e| {
+                    PluginError::NetworkError(format!("Failed to list pipeline steps: {}", e))
+                })?;
+
+                let paginated: BitbucketPaginatedResponse<PipelineStep> =
+                    self.handle_response(response).await?;
+                Ok(paginated.values)
+            })
+            .await
+    }
+
+    pub async fn trigger_pipeline(
+        &self, workspace: &str, repo_slug: &str, request: TriggerPipelineRequest,
+    ) -> PluginResult<Pipeline> {
+        self.retry_policy
+            .retry(|| async {
+                let url = format!(
+                    "{}/repositories/{}/{}/pipelines/",
+                    self.api_url, workspace, repo_slug
+                );
+                let response = self
+                    .http_client
+                    .post(&url)
+                    .json(&request)
+                    .send()
+                    .await
+                    .map_err(|e| {
+                        PluginError::NetworkError(format!("Failed to trigger pipeline: {}", e))
+                    })?;
+
+                self.handle_response(response).await
+            })
+            .await
+    }
+
+    pub async fn stop_pipeline(
+        &self, workspace: &str, repo_slug: &str, pipeline_uuid: &str,
+    ) -> PluginResult<()> {
+        // Bitbucket UUIDs have curly braces that need URL encoding
+        let uuid_with_braces = if pipeline_uuid.starts_with('{') {
+            pipeline_uuid.to_string()
+        } else {
+            format!("{{{}}}", pipeline_uuid)
+        };
+        let encoded_uuid = urlencoding::encode(&uuid_with_braces);
+
+        self.retry_policy
+            .retry(|| async {
+                let url = format!(
+                    "{}/repositories/{}/{}/pipelines/{}/stopPipeline",
+                    self.api_url, workspace, repo_slug, encoded_uuid
+                );
+                let response = self.http_client.post(&url).send().await.map_err(|e| {
+                    PluginError::NetworkError(format!("Failed to stop pipeline: {}", e))
+                })?;
+
+                let status = response.status();
+                if status.is_success() {
+                    Ok(())
+                } else {
+                    let error_text = response.text().await.unwrap_or_default();
+                    Err(PluginError::ApiError(format!(
+                        "Failed to stop pipeline ({}): {}",
+                        status, error_text
+                    )))
+                }
+            })
+            .await
+    }
+
+    async fn handle_response<T: serde::de::DeserializeOwned>(
+        &self, response: reqwest::Response,
+    ) -> PluginResult<T> {
+        let status = response.status();
+        let url = response.url().clone();
+
+        if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(PluginError::AuthenticationFailed(format!(
+                "Authentication failed for {}: {}",
+                url, error_text
+            )));
+        }
+
+        if status == StatusCode::NOT_FOUND {
+            return Err(PluginError::PipelineNotFound(format!(
+                "Resource not found: {}",
+                url
+            )));
+        }
+
+        if !status.is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(PluginError::ApiError(format!(
+                "Bitbucket API error ({}) for {}: {}",
+                status, url, error_text
+            )));
+        }
+
+        response.json::<T>().await.map_err(|e| {
+            PluginError::ApiError(format!(
+                "Failed to parse Bitbucket API response from {}: {}",
+                url, e
+            ))
+        })
+    }
+}

--- a/crates/pipedash-plugin-bitbucket/src/config.rs
+++ b/crates/pipedash-plugin-bitbucket/src/config.rs
@@ -1,0 +1,57 @@
+use std::collections::HashMap;
+
+use pipedash_plugin_api::{
+    PluginError,
+    PluginResult,
+};
+
+/// Format: bitbucket__{provider_id}__{workspace}__{repo_slug}
+pub(crate) fn parse_pipeline_id(id: &str) -> PluginResult<(i64, String, String)> {
+    let parts: Vec<&str> = id.split("__").collect();
+
+    if parts.len() < 4 || parts[0] != "bitbucket" {
+        return Err(PluginError::InvalidConfig(format!(
+            "Invalid pipeline ID format: {}",
+            id
+        )));
+    }
+
+    let provider_id = parts[1]
+        .parse::<i64>()
+        .map_err(|_| PluginError::InvalidConfig(format!("Invalid provider ID in: {}", id)))?;
+
+    let workspace = parts[2].to_string();
+    let repo_slug = parts[3].to_string();
+
+    Ok((provider_id, workspace, repo_slug))
+}
+
+pub(crate) fn parse_selected_items(config: &HashMap<String, String>) -> Option<Vec<String>> {
+    config.get("selected_items").map(|items| {
+        items
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect()
+    })
+}
+
+/// Only Bitbucket Cloud supported (Data Center has different API, no Pipelines)
+pub(crate) fn get_api_url() -> String {
+    "https://api.bitbucket.org/2.0".to_string()
+}
+
+/// API tokens replaced app passwords Sept 2025 (disabled June 2026)
+pub(crate) fn get_auth(config: &HashMap<String, String>) -> PluginResult<(String, String)> {
+    let email = config
+        .get("email")
+        .ok_or_else(|| PluginError::InvalidConfig("Missing Atlassian account email".to_string()))?
+        .clone();
+
+    let api_token = config
+        .get("api_token")
+        .ok_or_else(|| PluginError::InvalidConfig("Missing Bitbucket API token".to_string()))?
+        .clone();
+
+    Ok((email, api_token))
+}

--- a/crates/pipedash-plugin-bitbucket/src/lib.rs
+++ b/crates/pipedash-plugin-bitbucket/src/lib.rs
@@ -1,0 +1,11 @@
+mod client;
+mod config;
+mod mapper;
+mod metadata;
+mod plugin;
+mod schema;
+mod types;
+
+pub use plugin::BitbucketPlugin;
+
+pipedash_plugin_api::register_plugin!(BitbucketPlugin);

--- a/crates/pipedash-plugin-bitbucket/src/mapper.rs
+++ b/crates/pipedash-plugin-bitbucket/src/mapper.rs
@@ -1,0 +1,139 @@
+use std::collections::HashMap;
+
+use chrono::Utc;
+use pipedash_plugin_api::{
+    AvailablePipeline,
+    Pipeline,
+    PipelineRun,
+    PipelineStatus,
+};
+
+use crate::types;
+
+/// Bitbucket states: PENDING, PARSING, IN_PROGRESS, COMPLETED, PAUSED, HALTED
+/// Bitbucket results: SUCCESSFUL, FAILED, STOPPED, EXPIRED
+pub(crate) fn map_status(state: &types::PipelineState) -> PipelineStatus {
+    match state.name.as_str() {
+        "PENDING" => PipelineStatus::Pending,
+        "PARSING" => PipelineStatus::Running,
+        "IN_PROGRESS" => {
+            // IN_PROGRESS with stage.name="PAUSED" means waiting for manual approval
+            let is_paused = state
+                .stage
+                .as_ref()
+                .map(|s| s.name == "PAUSED")
+                .unwrap_or(false);
+            if is_paused {
+                PipelineStatus::Pending
+            } else {
+                PipelineStatus::Running
+            }
+        }
+        "PAUSED" | "HALTED" => PipelineStatus::Pending,
+        "COMPLETED" => match state.result.as_ref().map(|r| r.name.as_str()) {
+            Some("SUCCESSFUL") => PipelineStatus::Success,
+            Some("FAILED") | Some("ERROR") => PipelineStatus::Failed,
+            Some("STOPPED") | Some("EXPIRED") => PipelineStatus::Cancelled,
+            _ => PipelineStatus::Failed, // Unknown result -> Failed (safer than Success)
+        },
+        _ => PipelineStatus::Pending,
+    }
+}
+
+pub(crate) fn map_pipeline(
+    repo: &types::Repository, latest_pipeline: Option<&types::Pipeline>, provider_id: i64,
+) -> Pipeline {
+    let status = latest_pipeline
+        .map(|p| map_status(&p.state))
+        .unwrap_or(PipelineStatus::Pending);
+
+    let last_run = latest_pipeline.map(|p| p.created_on);
+    let branch = latest_pipeline.and_then(|p| p.target.ref_name.clone());
+
+    let mut metadata = HashMap::new();
+    metadata.insert(
+        "workspace".to_string(),
+        serde_json::json!(repo.workspace.slug),
+    );
+    metadata.insert("repo_slug".to_string(), serde_json::json!(repo.slug));
+
+    Pipeline {
+        id: format!(
+            "bitbucket__{}__{}__{}",
+            provider_id, repo.workspace.slug, repo.slug
+        ),
+        provider_id,
+        provider_type: "bitbucket".to_string(),
+        name: repo.name.clone(),
+        status,
+        last_run,
+        last_updated: Utc::now(),
+        repository: repo.full_name.clone(),
+        branch,
+        workflow_file: Some("bitbucket-pipelines.yml".to_string()),
+        metadata,
+    }
+}
+
+pub(crate) fn map_pipeline_run(
+    pipeline: &types::Pipeline, workspace: &str, repo_slug: &str, provider_id: i64,
+) -> PipelineRun {
+    let mut metadata = HashMap::new();
+    metadata.insert("workspace".to_string(), serde_json::json!(workspace));
+
+    if let Some(ref selector) = pipeline.target.selector {
+        metadata.insert(
+            "selector_type".to_string(),
+            serde_json::json!(selector.selector_type),
+        );
+        if let Some(ref pattern) = selector.pattern {
+            metadata.insert("selector_pattern".to_string(), serde_json::json!(pattern));
+        }
+    }
+
+    let logs_url = pipeline
+        .links
+        .html
+        .as_ref()
+        .map(|l| l.href.clone())
+        .unwrap_or_else(|| {
+            format!(
+                "https://bitbucket.org/{}/{}/pipelines/results/{}",
+                workspace, repo_slug, pipeline.build_number
+            )
+        });
+
+    PipelineRun {
+        id: format!(
+            "bitbucket__{}__{}__{}__{}",
+            provider_id, workspace, repo_slug, pipeline.build_number
+        ),
+        pipeline_id: format!("bitbucket__{}__{}__{}", provider_id, workspace, repo_slug),
+        run_number: pipeline.build_number,
+        status: map_status(&pipeline.state),
+        started_at: pipeline.created_on,
+        concluded_at: pipeline.completed_on,
+        duration_seconds: pipeline.duration_in_seconds,
+        logs_url,
+        commit_sha: pipeline.target.commit.as_ref().map(|c| c.hash.clone()),
+        commit_message: pipeline
+            .target
+            .commit
+            .as_ref()
+            .and_then(|c| c.message.clone()),
+        branch: pipeline.target.ref_name.clone(),
+        actor: pipeline.creator.as_ref().map(|u| u.display_name.clone()),
+        inputs: None,
+        metadata,
+    }
+}
+
+pub(crate) fn map_available_pipeline(repo: &types::Repository) -> AvailablePipeline {
+    AvailablePipeline {
+        id: repo.full_name.clone(),
+        name: repo.name.clone(),
+        description: repo.description.clone(),
+        organization: Some(repo.workspace.slug.clone()),
+        repository: Some(repo.slug.clone()),
+    }
+}

--- a/crates/pipedash-plugin-bitbucket/src/metadata.rs
+++ b/crates/pipedash-plugin-bitbucket/src/metadata.rs
@@ -1,0 +1,120 @@
+use pipedash_plugin_api::*;
+
+use crate::schema;
+
+pub fn create_metadata() -> PluginMetadata {
+    PluginMetadata {
+        name: "Bitbucket Pipelines".to_string(),
+        provider_type: "bitbucket".to_string(),
+        version: "0.1.0".to_string(),
+        description: "Monitor and trigger Bitbucket Cloud Pipelines CI/CD".to_string(),
+        author: Some("Pipedash Team".to_string()),
+        icon: Some("https://cdn.simpleicons.org/bitbucket/0052CC".to_string()),
+        config_schema: create_config_schema(),
+        table_schema: schema::create_table_schema(),
+        capabilities: create_capabilities(),
+        required_permissions: create_required_permissions(),
+        features: create_features(),
+    }
+}
+
+fn create_config_schema() -> ConfigSchema {
+    ConfigSchema::new()
+        .add_field(ConfigField {
+            key: "email".to_string(),
+            label: "Email".to_string(),
+            description: Some(
+                "Your Atlassian account email (found in Bitbucket Personal settings > Email)"
+                    .to_string(),
+            ),
+            field_type: ConfigFieldType::Text,
+            required: true,
+            default_value: None,
+            options: None,
+            validation_regex: None,
+            validation_message: None,
+        })
+        .add_field(ConfigField {
+            key: "api_token".to_string(),
+            label: "API Token".to_string(),
+            description: Some(
+                "Bitbucket API token with Repository:Read, Workspace:Read, and Pipelines:Read/Write scopes"
+                    .to_string(),
+            ),
+            field_type: ConfigFieldType::Password,
+            required: true,
+            default_value: None,
+            options: None,
+            validation_regex: None,
+            validation_message: None,
+        })
+}
+
+fn create_capabilities() -> PluginCapabilities {
+    PluginCapabilities {
+        pipelines: true,
+        pipeline_runs: true,
+        trigger: true,
+        agents: false,
+        artifacts: false,
+        queues: false,
+        custom_tables: false,
+    }
+}
+
+fn create_required_permissions() -> Vec<Permission> {
+    vec![
+        Permission {
+            name: "read:user:bitbucket".to_string(),
+            description: "Read current user information (for credential validation)".to_string(),
+            required: true,
+        },
+        Permission {
+            name: "read:repository:bitbucket".to_string(),
+            description: "Read repository information and source code access".to_string(),
+            required: true,
+        },
+        Permission {
+            name: "read:workspace:bitbucket".to_string(),
+            description: "Read workspace and workspace permission data".to_string(),
+            required: true,
+        },
+        Permission {
+            name: "read:pipeline:bitbucket".to_string(),
+            description: "Read pipeline runs, steps, logs, and status".to_string(),
+            required: true,
+        },
+        Permission {
+            name: "write:pipeline:bitbucket".to_string(),
+            description: "Trigger and cancel pipeline runs".to_string(),
+            required: false,
+        },
+    ]
+}
+
+fn create_features() -> Vec<Feature> {
+    vec![
+        Feature {
+            id: "view_pipelines".to_string(),
+            name: "View Pipelines".to_string(),
+            description: "View pipeline runs and status".to_string(),
+            required_permissions: vec![
+                "read:repository:bitbucket".to_string(),
+                "read:workspace:bitbucket".to_string(),
+                "read:pipeline:bitbucket".to_string(),
+            ],
+        },
+        Feature {
+            id: "trigger_pipelines".to_string(),
+            name: "Trigger Pipelines".to_string(),
+            description: "Start new pipeline runs".to_string(),
+            required_permissions: vec!["write:pipeline:bitbucket".to_string()],
+        },
+        Feature {
+            id: "cancel_pipelines".to_string(),
+            name: "Cancel Pipelines".to_string(),
+            description: "Stop running pipelines".to_string(),
+            required_permissions: vec!["write:pipeline:bitbucket".to_string()],
+        },
+    ]
+}

--- a/crates/pipedash-plugin-bitbucket/src/plugin.rs
+++ b/crates/pipedash-plugin-bitbucket/src/plugin.rs
@@ -1,0 +1,439 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::future::join_all;
+use pipedash_plugin_api::*;
+use reqwest::header::{
+    HeaderMap,
+    HeaderValue,
+    AUTHORIZATION,
+};
+
+use crate::{
+    client,
+    config,
+    mapper,
+    metadata,
+    types,
+};
+
+pub struct BitbucketPlugin {
+    metadata: PluginMetadata,
+    client: Option<client::BitbucketClient>,
+    provider_id: Option<i64>,
+    config: HashMap<String, String>,
+}
+
+impl Default for BitbucketPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BitbucketPlugin {
+    pub fn new() -> Self {
+        Self {
+            metadata: metadata::create_metadata(),
+            client: None,
+            provider_id: None,
+            config: HashMap::new(),
+        }
+    }
+
+    fn client(&self) -> PluginResult<&client::BitbucketClient> {
+        self.client
+            .as_ref()
+            .ok_or_else(|| PluginError::Internal("Plugin not initialized".to_string()))
+    }
+
+    async fn fetch_all_repositories(&self) -> PluginResult<Vec<types::Repository>> {
+        let client = self.client()?;
+        let mut all_repos = Vec::new();
+        let mut page = 1;
+
+        // Max 5000 repos; use selected_items to filter if needed
+        const MAX_PAGES: usize = 50;
+
+        loop {
+            let params = PaginationParams {
+                page,
+                page_size: 100,
+            };
+            let response = client.list_all_repositories(&params).await?;
+
+            if response.items.is_empty() {
+                break;
+            }
+
+            all_repos.extend(response.items);
+
+            if !response.has_more || page >= MAX_PAGES {
+                break;
+            }
+            page += 1;
+        }
+
+        if let Some(selected) = config::parse_selected_items(&self.config) {
+            Ok(all_repos
+                .into_iter()
+                .filter(|r| selected.contains(&r.full_name))
+                .collect())
+        } else {
+            Ok(all_repos)
+        }
+    }
+
+    /// Bitbucket API only supports fetching by UUID, not build_number
+    async fn find_pipeline_by_build_number(
+        &self, workspace: &str, repo_slug: &str, build_number: i64,
+    ) -> PluginResult<types::Pipeline> {
+        let client = self.client()?;
+        let pipelines = client.list_pipelines(workspace, repo_slug, 100).await?;
+
+        pipelines
+            .into_iter()
+            .find(|p| p.build_number == build_number)
+            .ok_or_else(|| {
+                PluginError::PipelineNotFound(format!(
+                    "Pipeline run #{} not found in recent 100 runs for {}/{}",
+                    build_number, workspace, repo_slug
+                ))
+            })
+    }
+}
+
+#[async_trait]
+impl Plugin for BitbucketPlugin {
+    fn metadata(&self) -> &PluginMetadata {
+        &self.metadata
+    }
+
+    fn provider_type(&self) -> &str {
+        "bitbucket"
+    }
+
+    fn initialize(
+        &mut self, provider_id: i64, config: HashMap<String, String>,
+    ) -> PluginResult<()> {
+        let (email, api_token) = config::get_auth(&config)?;
+        let api_url = config::get_api_url();
+
+        let credentials = format!("{}:{}", email, api_token);
+        let encoded = base64::Engine::encode(
+            &base64::engine::general_purpose::STANDARD,
+            credentials.as_bytes(),
+        );
+        let auth_value = format!("Basic {}", encoded);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&auth_value)
+                .map_err(|e| PluginError::InvalidConfig(format!("Invalid auth format: {}", e)))?,
+        );
+
+        let http_client = reqwest::Client::builder()
+            .use_rustls_tls()
+            .pool_max_idle_per_host(10)
+            .default_headers(headers)
+            .timeout(Duration::from_secs(30))
+            .connect_timeout(Duration::from_secs(10))
+            .tcp_keepalive(Duration::from_secs(60))
+            .build()
+            .map_err(|e| PluginError::Internal(format!("Failed to build HTTP client: {}", e)))?;
+
+        self.client = Some(client::BitbucketClient::new(http_client, api_url));
+        self.provider_id = Some(provider_id);
+        self.config = config;
+
+        Ok(())
+    }
+
+    async fn validate_credentials(&self) -> PluginResult<bool> {
+        let client = self.client()?;
+        client.get_user().await?;
+        Ok(true)
+    }
+
+    async fn fetch_organizations(&self) -> PluginResult<Vec<Organization>> {
+        let client = self.client()?;
+        let workspaces = client.list_workspaces().await?;
+
+        Ok(workspaces
+            .into_iter()
+            .map(|w| Organization {
+                id: w.uuid,
+                name: w.name,
+                description: Some(w.slug),
+            })
+            .collect())
+    }
+
+    async fn fetch_available_pipelines(
+        &self, params: Option<PaginationParams>,
+    ) -> PluginResult<PaginatedResponse<AvailablePipeline>> {
+        let client = self.client()?;
+        let params = params.unwrap_or_default();
+
+        let response = client.list_all_repositories(&params).await?;
+
+        let available = response
+            .items
+            .iter()
+            .map(mapper::map_available_pipeline)
+            .collect();
+
+        Ok(PaginatedResponse::new(
+            available,
+            response.page,
+            response.page_size,
+            response.total_count,
+        ))
+    }
+
+    async fn fetch_available_pipelines_filtered(
+        &self, org: Option<String>, search: Option<String>, params: Option<PaginationParams>,
+    ) -> PluginResult<PaginatedResponse<AvailablePipeline>> {
+        let client = self.client()?;
+        let params = params.unwrap_or_default();
+
+        let response = if let Some(workspace) = &org {
+            client.list_repositories(workspace, &params).await?
+        } else {
+            client.list_all_repositories(&params).await?
+        };
+
+        let mut available: Vec<AvailablePipeline> = response
+            .items
+            .iter()
+            .map(mapper::map_available_pipeline)
+            .collect();
+
+        if let Some(search_term) = search {
+            let search_lower = search_term.to_lowercase();
+            available.retain(|p| {
+                p.name.to_lowercase().contains(&search_lower)
+                    || p.id.to_lowercase().contains(&search_lower)
+            });
+        }
+
+        Ok(PaginatedResponse::new(
+            available,
+            params.page,
+            params.page_size,
+            response.total_count,
+        ))
+    }
+
+    async fn fetch_pipelines(&self) -> PluginResult<Vec<Pipeline>> {
+        let provider_id = self
+            .provider_id
+            .ok_or_else(|| PluginError::Internal("Provider ID not set".to_string()))?;
+
+        let client = self.client()?;
+        let repos = self.fetch_all_repositories().await?;
+
+        let pipeline_futures = repos.iter().map(|repo| async move {
+            let pipelines = client
+                .list_pipelines(&repo.workspace.slug, &repo.slug, 1)
+                .await
+                .ok()?;
+            let latest = pipelines.first();
+            Some(mapper::map_pipeline(repo, latest, provider_id))
+        });
+
+        let results: Vec<Option<Pipeline>> = join_all(pipeline_futures).await;
+        Ok(results.into_iter().flatten().collect())
+    }
+
+    async fn fetch_run_history(
+        &self, pipeline_id: &str, limit: usize,
+    ) -> PluginResult<Vec<PipelineRun>> {
+        let (provider_id, workspace, repo_slug) = config::parse_pipeline_id(pipeline_id)?;
+        let client = self.client()?;
+
+        let pipelines = client.list_pipelines(&workspace, &repo_slug, limit).await?;
+
+        Ok(pipelines
+            .iter()
+            .map(|p| mapper::map_pipeline_run(p, &workspace, &repo_slug, provider_id))
+            .collect())
+    }
+
+    async fn fetch_run_details(
+        &self, pipeline_id: &str, run_number: i64,
+    ) -> PluginResult<PipelineRun> {
+        let (provider_id, workspace, repo_slug) = config::parse_pipeline_id(pipeline_id)?;
+
+        let pipeline = self
+            .find_pipeline_by_build_number(&workspace, &repo_slug, run_number)
+            .await?;
+
+        Ok(mapper::map_pipeline_run(
+            &pipeline,
+            &workspace,
+            &repo_slug,
+            provider_id,
+        ))
+    }
+
+    async fn fetch_workflow_parameters(
+        &self, _workflow_id: &str,
+    ) -> PluginResult<Vec<WorkflowParameter>> {
+        Ok(vec![
+            WorkflowParameter {
+                name: "ref".to_string(),
+                label: Some("Branch".to_string()),
+                description: Some("Branch name to run pipeline on".to_string()),
+                param_type: WorkflowParameterType::String {
+                    default: Some("main".to_string()),
+                },
+                required: true,
+            },
+            WorkflowParameter {
+                name: "custom_pipeline".to_string(),
+                label: Some("Custom Pipeline".to_string()),
+                description: Some("Name of custom pipeline to run (optional)".to_string()),
+                param_type: WorkflowParameterType::String { default: None },
+                required: false,
+            },
+        ])
+    }
+
+    async fn trigger_pipeline(&self, params: TriggerParams) -> PluginResult<String> {
+        let (_, workspace, repo_slug) = config::parse_pipeline_id(&params.workflow_id)?;
+        let client = self.client()?;
+
+        let ref_name = params
+            .inputs
+            .as_ref()
+            .and_then(|i| i.get("ref"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("main")
+            .to_string();
+
+        let custom_pipeline = params
+            .inputs
+            .as_ref()
+            .and_then(|i| i.get("custom_pipeline"))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty());
+
+        let request = types::TriggerPipelineRequest {
+            target: types::TriggerTarget {
+                target_type: "pipeline_ref_target".to_string(),
+                ref_name,
+                ref_type: "branch".to_string(),
+                selector: custom_pipeline.map(|name| types::TriggerSelector {
+                    selector_type: "custom".to_string(),
+                    pattern: Some(name.to_string()),
+                }),
+            },
+        };
+
+        let pipeline = client
+            .trigger_pipeline(&workspace, &repo_slug, request)
+            .await?;
+
+        let url = pipeline.links.html.map(|l| l.href).unwrap_or_else(|| {
+            format!(
+                "https://bitbucket.org/{}/{}/pipelines/results/{}",
+                workspace, repo_slug, pipeline.build_number
+            )
+        });
+
+        Ok(url)
+    }
+
+    async fn cancel_run(&self, pipeline_id: &str, run_number: i64) -> PluginResult<()> {
+        let (_, workspace, repo_slug) = config::parse_pipeline_id(pipeline_id)?;
+        let client = self.client()?;
+
+        let pipeline = self
+            .find_pipeline_by_build_number(&workspace, &repo_slug, run_number)
+            .await?;
+
+        // Bitbucket API only stops IN_PROGRESS pipelines; PAUSED ones require UI
+        let state = pipeline.state.name.as_str();
+        if state == "PAUSED" || state == "HALTED" {
+            return Err(PluginError::ApiError(format!(
+                "Cannot cancel pipeline in '{}' state. Pipelines waiting for manual approval \
+                 must be cancelled directly in Bitbucket UI.",
+                state
+            )));
+        }
+
+        if state == "COMPLETED" {
+            return Err(PluginError::ApiError(
+                "Cannot cancel a completed pipeline.".to_string(),
+            ));
+        }
+
+        // API returns 204 but doesn't stop pipelines waiting for manual trigger
+        if state == "IN_PROGRESS" {
+            let pipeline_is_paused = pipeline
+                .state
+                .stage
+                .as_ref()
+                .map(|s| s.name == "PAUSED")
+                .unwrap_or(false);
+
+            if pipeline_is_paused {
+                return Err(PluginError::ApiError(
+                    "Cannot cancel pipeline waiting for manual approval. \
+                     Please cancel directly in Bitbucket UI."
+                        .to_string(),
+                ));
+            }
+
+            let steps = client
+                .list_steps(&workspace, &repo_slug, &pipeline.uuid)
+                .await?;
+
+            let has_paused_step = steps.iter().any(|step| {
+                step.state.name == "PENDING"
+                    && step
+                        .state
+                        .stage
+                        .as_ref()
+                        .map(|s| s.name == "PAUSED")
+                        .unwrap_or(false)
+            });
+
+            if has_paused_step {
+                return Err(PluginError::ApiError(
+                    "Cannot cancel pipeline with steps waiting for manual approval. \
+                     Please cancel directly in Bitbucket UI."
+                        .to_string(),
+                ));
+            }
+        }
+
+        client
+            .stop_pipeline(&workspace, &repo_slug, &pipeline.uuid)
+            .await
+    }
+
+    async fn fetch_agents(&self) -> PluginResult<Vec<BuildAgent>> {
+        Err(PluginError::NotSupported(
+            "Bitbucket Pipelines uses Atlassian infrastructure - no agent monitoring".to_string(),
+        ))
+    }
+
+    async fn fetch_artifacts(&self, _run_id: &str) -> PluginResult<Vec<BuildArtifact>> {
+        Err(PluginError::NotSupported(
+            "Artifact fetching not yet implemented for Bitbucket".to_string(),
+        ))
+    }
+
+    async fn fetch_queues(&self) -> PluginResult<Vec<BuildQueue>> {
+        Err(PluginError::NotSupported(
+            "Build queues not supported by Bitbucket Pipelines".to_string(),
+        ))
+    }
+
+    fn get_migrations(&self) -> Vec<String> {
+        vec![]
+    }
+}

--- a/crates/pipedash-plugin-bitbucket/src/schema.rs
+++ b/crates/pipedash-plugin-bitbucket/src/schema.rs
@@ -1,0 +1,51 @@
+use pipedash_plugin_api::*;
+
+pub fn create_table_schema() -> schema::TableSchema {
+    schema::TableSchema::new()
+        .add_table(create_pipeline_runs_table())
+        .add_table(pipedash_plugin_api::defaults::default_pipelines_table())
+}
+
+fn create_pipeline_runs_table() -> schema::TableDefinition {
+    let mut table = pipedash_plugin_api::defaults::default_pipeline_runs_table();
+
+    // Insert at index 1 to show workspace early (after pipeline_id)
+    table.columns.insert(1, create_workspace_column());
+    table.columns.push(create_selector_column());
+
+    table
+}
+
+fn create_workspace_column() -> schema::ColumnDefinition {
+    schema::ColumnDefinition {
+        id: "workspace".to_string(),
+        label: "Workspace".to_string(),
+        description: Some("Bitbucket workspace".to_string()),
+        field_path: "metadata.workspace".to_string(),
+        data_type: schema::ColumnDataType::String,
+        renderer: schema::CellRenderer::Badge,
+        visibility: schema::ColumnVisibility::Always,
+        default_visible: false,
+        width: Some(120),
+        sortable: true,
+        filterable: false,
+        align: None,
+    }
+}
+
+fn create_selector_column() -> schema::ColumnDefinition {
+    schema::ColumnDefinition {
+        id: "selector_type".to_string(),
+        label: "Type".to_string(),
+        description: Some("Pipeline trigger type (custom, branches, default, tags)".to_string()),
+        field_path: "metadata.selector_type".to_string(),
+        data_type: schema::ColumnDataType::String,
+        renderer: schema::CellRenderer::Badge,
+        visibility: schema::ColumnVisibility::WhenPresent,
+        default_visible: false,
+        width: Some(100),
+        sortable: false,
+        filterable: false,
+        align: None,
+    }
+}

--- a/crates/pipedash-plugin-bitbucket/src/types.rs
+++ b/crates/pipedash-plugin-bitbucket/src/types.rs
@@ -1,0 +1,183 @@
+use chrono::{
+    DateTime,
+    Utc,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct User {
+    pub uuid: String,
+    pub display_name: String,
+    pub nickname: Option<String>,
+    pub account_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Workspace {
+    pub uuid: String,
+    pub slug: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Repository {
+    pub uuid: String,
+    pub name: String,
+    pub full_name: String,
+    pub slug: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    pub workspace: WorkspaceRef,
+    pub links: RepositoryLinks,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkspaceRef {
+    pub uuid: String,
+    pub slug: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RepositoryLinks {
+    pub html: Link,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Link {
+    pub href: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Pipeline {
+    pub uuid: String,
+    pub build_number: i64,
+    pub state: PipelineState,
+    pub target: PipelineTarget,
+    pub created_on: DateTime<Utc>,
+    #[serde(default)]
+    pub completed_on: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub duration_in_seconds: Option<i64>,
+    #[serde(default)]
+    pub creator: Option<User>,
+    pub links: PipelineLinks,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PipelineState {
+    pub name: String,
+    #[serde(default)]
+    pub result: Option<PipelineResult>,
+    /// Present when IN_PROGRESS but paused for manual approval
+    #[serde(default)]
+    pub stage: Option<PipelineStateStage>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PipelineStateStage {
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PipelineResult {
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PipelineTarget {
+    #[serde(rename = "type")]
+    pub target_type: String,
+    #[serde(default)]
+    pub ref_name: Option<String>,
+    #[serde(default)]
+    pub ref_type: Option<String>,
+    #[serde(default)]
+    pub commit: Option<PipelineCommit>,
+    #[serde(default)]
+    pub selector: Option<PipelineSelector>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PipelineCommit {
+    pub hash: String,
+    #[serde(default)]
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PipelineSelector {
+    #[serde(rename = "type")]
+    pub selector_type: String,
+    #[serde(default)]
+    pub pattern: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PipelineLinks {
+    #[serde(default, rename = "self")]
+    pub self_link: Option<Link>,
+    #[serde(default)]
+    pub html: Option<Link>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PipelineStep {
+    pub uuid: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    pub state: PipelineStepState,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PipelineStepState {
+    pub name: String,
+    /// Present when PENDING and waiting for manual trigger
+    #[serde(default)]
+    pub stage: Option<PipelineStepStage>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PipelineStepStage {
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PaginatedResponse<T> {
+    pub values: Vec<T>,
+    #[serde(default)]
+    pub page: Option<usize>,
+    pub pagelen: usize,
+    #[serde(default)]
+    pub size: Option<usize>,
+    #[serde(default)]
+    pub next: Option<String>,
+    #[serde(default)]
+    pub previous: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TriggerPipelineRequest {
+    pub target: TriggerTarget,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TriggerTarget {
+    #[serde(rename = "type")]
+    pub target_type: String,
+    pub ref_name: String,
+    pub ref_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selector: Option<TriggerSelector>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TriggerSelector {
+    #[serde(rename = "type")]
+    pub selector_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pattern: Option<String>,
+}

--- a/crates/pipedash/Cargo.toml
+++ b/crates/pipedash/Cargo.toml
@@ -17,6 +17,7 @@ chrono.workspace = true
 futures.workspace = true
 keyring.workspace = true
 pipedash-plugin-api.workspace = true
+pipedash-plugin-bitbucket.workspace = true
 pipedash-plugin-buildkite.workspace = true
 pipedash-plugin-github.workspace = true
 pipedash-plugin-gitlab.workspace = true

--- a/crates/pipedash/src/plugins.rs
+++ b/crates/pipedash/src/plugins.rs
@@ -26,6 +26,7 @@ macro_rules! define_plugins {
 
 define_plugins![
     ("github", pipedash_plugin_github::GitHubPlugin),
+    ("bitbucket", pipedash_plugin_bitbucket::BitbucketPlugin),
     ("buildkite", pipedash_plugin_buildkite::BuildkitePlugin),
     ("gitlab", pipedash_plugin_gitlab::GitLabPlugin),
     ("jenkins", pipedash_plugin_jenkins::JenkinsPlugin),


### PR DESCRIPTION
## Changes
Implement PIP-15 - Complete Bitbucket Pipelines plugin for Pipedash:
- New `pipedash-plugin-bitbucket` crate with full CI/CD integration
- List pipelines from all accessible repositories with automatic pagination
- Trigger new pipeline runs with custom branch/pipeline selection
- Cancel running pipelines with proper manual approval state validation
- Add 30-second timeout protection for provider fetch operations to prevent hanging
- Clean, developer-friendly code with minimal, essential comments only

## Checklist before merging:
- [x] I have reviewed my own code.
- [x] I have tested the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] My changes do not break any existing functionalities.

## Anything else?
This plugin uses Bitbucket Cloud API v2.0 only (Data Center not supported). Implements proper handling for pipelines waiting on manual approval steps and prevents cancellation via API (must use Bitbucket UI).


ref: https://github.com/hcavarsan/pipedash/issues/23