### PR TITLE
fix: close unauthenticated setup/config auth bypass (#39)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ secrecy = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
+subtle = "2.6"
 shellexpand = "3.1"
 sqlx = { version = "0.8", features = [
   "chrono",

--- a/crates/pipedash-web/Cargo.toml
+++ b/crates/pipedash-web/Cargo.toml
@@ -31,6 +31,7 @@ pipedash-plugin-api.workspace = true
 rust-embed.workspace = true
 # TLS/Crypto
 rustls.workspace = true
+subtle.workspace = true
 # Serialization
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/pipedash-web/src/error.rs
+++ b/crates/pipedash-web/src/error.rs
@@ -55,10 +55,17 @@ impl AppError {
         )
     }
 
-    pub fn unauthorized(message: impl Into<String>) -> Self {
+     pub fn unauthorized(message: impl Into<String>) -> Self {
         Self::new(
             StatusCode::UNAUTHORIZED,
             ApiError::new("UNAUTHORIZED", message),
+        )
+    }
+
+    pub fn conflict(message: impl Into<String>) -> Self {
+        Self::new(
+            StatusCode::CONFLICT,
+            ApiError::new("CONFLICT", message),
         )
     }
 

--- a/crates/pipedash-web/src/main.rs
+++ b/crates/pipedash-web/src/main.rs
@@ -8,6 +8,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use anyhow::Context;
+use subtle::ConstantTimeEq;
 use axum::{
     extract::Request,
     http::{
@@ -72,7 +73,7 @@ async fn auth_middleware(req: Request, next: Next) -> Result<Response, StatusCod
     match auth_header {
         Some(h)
             if h.strip_prefix("Bearer ")
-                .map(|t| t == token)
+                .map(|t| t.as_bytes().ct_eq(token.as_bytes()).into()]
                 .unwrap_or(false) =>
         {
             Ok(next.run(req).await)
@@ -90,7 +91,7 @@ impl ApiServerConfig {
 
         let cors_allow_all = std::env::var("PIPEDASH_CORS_ALLOW_ALL")
             .map(|v| v == "true" || v == "1")
-            .unwrap_or(true);
+            .unwrap_or(false);
 
         let enable_embedded_frontend = std::env::var("PIPEDASH_EMBEDDED_FRONTEND")
             .map(|v| v == "true" || v == "1")

--- a/crates/pipedash-web/src/routes/setup.rs
+++ b/crates/pipedash-web/src/routes/setup.rs
@@ -70,6 +70,15 @@ async fn get_setup_status() -> Json<SetupStatusResponse> {
 async fn create_initial_config(
     State(state): State<AppState>, Json(req): Json<CreateInitialConfigRequest>,
 ) -> ApiResult<Json<serde_json::Value>> {
+    {
+        let inner = state.inner.read().await;
+        if !inner.setup_required {
+            return Err(AppError::conflict(
+                "Setup already completed. Cannot re-initialize an already-configured instance.",
+            ));
+        }
+    }
+
     let config = req.config;
     let config_path = ConfigLoader::discover_config_path();
 


### PR DESCRIPTION
## Summary

Fixes the critical auth bypass in `pipedash-web` where an unauthenticated caller could take over a running instance via `POST /api/v1/setup/config` (issue #39).

## Changes

### 1. Setup guard — reject re-initialization (item 1)
`create_initial_config` now checks `state.inner.setup_required` and returns `409 Conflict` when setup has already completed. This is the primary fix that closes the bypass — only an instance that genuinely needs setup will accept the `/setup/config` endpoint.

### 2. Constant-time token comparison (item 4)  
Replaced the `==` comparison on the bearer token with `subtle::ConstantTimeEq::ct_eq` to prevent timing attacks on the auth token.

### 3. Secure CORS default (item 5)
Changed the default for `PIPEDASH_CORS_ALLOW_ALL` from `true` to `false`. The permissive default (`Allow` for all origins/methods/headers) made the auth bypass reachable from any web page — an attacking page could drive the bypass and read responses.

## Scope note (not addressed in this PR)

- **Item 2** (move vault password out of process env): requires broader refactoring of the storage layer and vault unlock/lock flow. Documented in the issue's §Suggested fix.
- **Item 3** (separate API credential from vault password): schema/config change.
- **SSRF via provider `base_url`**: separate issue, tracked independently.

## Testing

No Rust toolchain available in this environment to compile/run tests. The changes are straightforward guard + config changes. The setup guard adds a single early-return path guarded by the existing `setup_required` flag (already set in `AppState::setup_mode` vs `AppState::initialized`). CI will validate compilation.

## Links

Fixes #39
